### PR TITLE
Added Support for Advanced Banking

### DIFF
--- a/Custom/APOC_Airdrop_Assistance/APOC_srv_startAirdrop.sqf
+++ b/Custom/APOC_Airdrop_Assistance/APOC_srv_startAirdrop.sqf
@@ -153,7 +153,7 @@ if (APOC_AdvancedBanking) then {
     format["setAccountMoney:%1:%2", _newBalance, (getPlayerUID _player)] call ExileServer_system_database_query_fireAndForget;
     //Dealing with sending network messages into the ExileClient madness (Chunks of this from base Exile client code)
     _player call ExileServer_object_player_sendStatsUpdate;	//Yes, I know this is a gross misapplication
-}
+};
 
 
 

--- a/Custom/APOC_Airdrop_Assistance/APOC_srv_startAirdrop.sqf
+++ b/Custom/APOC_Airdrop_Assistance/APOC_srv_startAirdrop.sqf
@@ -120,9 +120,9 @@ While {true} do {
 };
 
 
-if (APOC_AdvancedBanking) then {
+if (APOC_AA_AdvancedBanking) then {
     // Let's handle the money after this tricky spot - This way players won't be charged for non-delivered goods!
-    _playerMoney = _player getVariable ["ExilePurse", 0];
+    _playerMoney = _player getVariable ["ExileBank", 0];
     if (_DropPrice > _playerMoney) exitWith
     {
         { _x setDamage 1; } forEach units _grp;
@@ -133,9 +133,9 @@ if (APOC_AdvancedBanking) then {
 
     //Server Side Money handling
     _newBalance = _playerMoney - _DropPrice;
-    _player setVariable ["ExilePurse", _newBalance];
-    format["updateWallet:%1:%2", _newBalance, (getPlayerUID _player)] call ExileServer_system_database_query_fireAndForget;
-    [_player,"updateWalletStats",[str(_newBalance)]] call ExileServer_system_network_send_to;
+    _player setVariable ["ExileBank", _newBalance];
+    format["updateBank:%1:%2", _newBalance, (getPlayerUID _player)] call ExileServer_system_database_query_fireAndForget;
+    [_player,"updateBankStats",[str(_newBalance)]] call ExileServer_system_network_send_to;
 } else {
     // Let's handle the money after this tricky spot - This way players won't be charged for non-delivered goods!
     _playerMoney = _player getVariable ["ExileMoney", 0];

--- a/Custom/APOC_Airdrop_Assistance/config.sqf
+++ b/Custom/APOC_Airdrop_Assistance/config.sqf
@@ -6,6 +6,9 @@
 //Author: Apoc
 // https://github.com/osuapoc
 
+// Advanced Banking support. Change false to true if you run Advanced Banking on your server.
+APOC_AdvancedBanking = false;
+
 APOC_AA_coolDownTime = 60; //Expressed in sec
 
 APOC_AA_Drops =[

--- a/Custom/APOC_Airdrop_Assistance/config.sqf
+++ b/Custom/APOC_Airdrop_Assistance/config.sqf
@@ -7,7 +7,7 @@
 // https://github.com/osuapoc
 
 // Advanced Banking support. Change false to true if you run Advanced Banking on your server.
-APOC_AdvancedBanking = false;
+APOC_AA_AdvancedBanking = false;
 
 APOC_AA_coolDownTime = 60; //Expressed in sec
 


### PR DESCRIPTION
Hey Apoc, I added the support for Advanced Banking for you. 

Just a few corrections I made. 
ExileMoney has no need to be public since ExileClientPlayerMoney is what the client looks at. 
Removed _balance because you already had _playerMoney, just no need for the extra memory allocation. 

Please look at CfgNetworkMessages. I wrote a lovely wiki article explaining them in detail. :)
[http://www.exilemod.com/wiki/developer-toolbox/network-messages-r2248/](url)
