### PR TITLE
Locker Use branch

### DIFF
--- a/Custom/APOC_Airdrop_Assistance/config.sqf
+++ b/Custom/APOC_Airdrop_Assistance/config.sqf
@@ -8,6 +8,7 @@
 
 // Advanced Banking support. Change false to true if you run Advanced Banking on your server.
 APOC_AA_AdvancedBanking = false;
+APOC_AA_UseExileLockerFunds = false;
 
 APOC_AA_coolDownTime = 60; //Expressed in sec
 

--- a/xm8Apps/Apps/APOC_Airdrop_Assistance/APOC_Airdrop_Assistance_XM8.sqf
+++ b/xm8Apps/Apps/APOC_Airdrop_Assistance/APOC_Airdrop_Assistance_XM8.sqf
@@ -228,8 +228,12 @@ fn_OrderDrop = {
       };
       //diag_log format["AAA - Made it to line 203!, _DropPrice %1",_DropPrice];
     ////////////////////////////////////////////////////////
-
-    _playerMoney = player getVariable ["ExileMoney", 0];
+    if (APOC_AA_UseExileLockerFunds) then {
+        _playerMoney = player getVariable ["ExileLocker",0];
+    } else {
+        _playerMoney = player getVariable ["ExileMoney", 0];
+    };
+    
     if (_DropPrice > _playerMoney) exitWith
       {
 


### PR DESCRIPTION
Changes to allow for the use of ExileLocker funds instead of funds carried on the player to call in an airdrop.
